### PR TITLE
LocalAddr and RemoteAddr to return sensible value

### DIFF
--- a/mockconn.go
+++ b/mockconn.go
@@ -145,11 +145,11 @@ func (c *Conn) Closed() bool {
 }
 
 func (c *Conn) LocalAddr() net.Addr {
-	return nil
+	return &net.TCPAddr{net.IP{127, 0, 0, 1}, 1234, ""}
 }
 
 func (c *Conn) RemoteAddr() net.Addr {
-	return nil
+	return &net.TCPAddr{net.IP{8, 8, 8, 8}, 1234, ""}
 }
 
 func (c *Conn) SetDeadline(t time.Time) error {


### PR DESCRIPTION
With this change,`mockconn` can be used to test code requires the two methods to return a non-nil value. @oxtoacart does it look ok?