### PR TITLE
always protect numOpen to avoid data race

### DIFF
--- a/mockconn.go
+++ b/mockconn.go
@@ -123,7 +123,9 @@ func (d *dialer) Dial(network, addr string) (net.Conn, error) {
 	if d.dialError != nil {
 		return nil, d.dialError
 	}
+	d.mx.Lock()
 	d.numOpen++
+	d.mx.Unlock()
 	return &Conn{
 		autoClose:      d.autoClose,
 		responseReader: bytes.NewBuffer(d.responseData),


### PR DESCRIPTION
See https://app.wercker.com/getlantern/flashlight/runs/build/5daf742439029f0008da25a7?step=5daf7446f947d1000977d0fb for one case it's happening.
